### PR TITLE
Make map hover temporary, click persistent

### DIFF
--- a/components/Map.jsx
+++ b/components/Map.jsx
@@ -61,11 +61,6 @@ const MapChart = ({ filterOptions, setFilterOptions }) => {
               {geographies.map((geo) => (
                 <g cursor={statesSet.has(geo.properties.name) ? 'pointer' : ''}>
                   <Geography
-                    style={{
-                      cursor: 'pointer',
-                      fill: 'red',
-                      border: '1px solid black',
-                    }}
                     key={geo.rsmKey}
                     stroke="#FFF"
                     geography={geo}

--- a/components/Map.jsx
+++ b/components/Map.jsx
@@ -59,23 +59,30 @@ const MapChart = ({ filterOptions, setFilterOptions }) => {
           {({ geographies }) => (
             <>
               {geographies.map((geo) => (
-                <Geography
-                  key={geo.rsmKey}
-                  stroke="#FFF"
-                  geography={geo}
-                  fill="#6f44ff"
-                  opacity={statesSet.has(geo.properties.name) ? 1 : 0.15}
-                  onClick={() => {
-                    if (statesSet.has(geo.properties.name)) {
-                      handleClick(geo.properties.name)
-                    }
-                  }}
-                  onMouseOver={() => {
-                    if (statesSet.has(geo.properties.name)) {
-                      handleHover(geo.properties.name)
-                    }
-                  }}
-                />
+                <g cursor={statesSet.has(geo.properties.name) ? 'pointer' : ''}>
+                  <Geography
+                    style={{
+                      cursor: 'pointer',
+                      fill: 'red',
+                      border: '1px solid black',
+                    }}
+                    key={geo.rsmKey}
+                    stroke="#FFF"
+                    geography={geo}
+                    fill="#6f44ff"
+                    opacity={statesSet.has(geo.properties.name) ? 1 : 0.15}
+                    onClick={() => {
+                      if (statesSet.has(geo.properties.name)) {
+                        handleClick(geo.properties.name)
+                      }
+                    }}
+                    onMouseOver={() => {
+                      if (statesSet.has(geo.properties.name)) {
+                        handleHover(geo.properties.name)
+                      }
+                    }}
+                  />
+                </g>
               ))}
             </>
           )}

--- a/components/Map.jsx
+++ b/components/Map.jsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { ComposableMap, Geographies, Geography } from 'react-simple-maps'
 import states from '../data/states'
 
@@ -20,19 +20,40 @@ const nameToCodes = {
   Georgia: 'GA',
 }
 
+// MapChart supports temporary filters on hover, but reverts to the previous configuration onMouseLeave.
+// Clicking a state persists the new filter configuration.
 const MapChart = ({ filterOptions, setFilterOptions }) => {
+  const [previousFilterOptions, setPreviousFilterOptions] = useState({})
   const statesData = states()
 
-  const handleClick = (name) => {
+  const handleHover = (name) => {
     const code = nameToCodes[name]
+
     setFilterOptions({
       ...filterOptions,
       state: code,
     })
   }
 
+  const handleClick = (name) => {
+    const code = nameToCodes[name]
+
+    setPreviousFilterOptions({
+      ...filterOptions,
+      state: code,
+    })
+  }
+
   return (
-    <div style={{ width: 400 }}>
+    <div
+      style={{ width: 400 }}
+      onMouseEnter={() => {
+        setPreviousFilterOptions(filterOptions)
+      }}
+      onMouseLeave={() => {
+        setFilterOptions(previousFilterOptions)
+      }}
+    >
       <ComposableMap projection="geoAlbersUsa">
         <Geographies geography={statesData}>
           {({ geographies }) => (
@@ -44,9 +65,14 @@ const MapChart = ({ filterOptions, setFilterOptions }) => {
                   geography={geo}
                   fill="#6f44ff"
                   opacity={statesSet.has(geo.properties.name) ? 1 : 0.15}
-                  onMouseOver={() => {
+                  onClick={() => {
                     if (statesSet.has(geo.properties.name)) {
                       handleClick(geo.properties.name)
+                    }
+                  }}
+                  onMouseOver={() => {
+                    if (statesSet.has(geo.properties.name)) {
+                      handleHover(geo.properties.name)
                     }
                   }}
                 />


### PR DESCRIPTION
Scatterplot click targets are small and movement is more exploratory since you don't know what you're getting ahead of time. This makes filter-on-hover desirable over filter-on-click. Scatterplot also doesn't interact with any of the dropdown filters, so there's no risk of altering a filter configuration on hover.

In contrast, the Map overrides the State dropdown filter, leaving a persistent change even if you hover over it briefly or unintentionally.

Despite these contrasting use cases, it would be confusing to have two totally different interactions (i.e. hover for Scatterplot, click for Map).

As an attempt to reconcile these competing demands, the Map now stores a "previous filter configuration" that it reverts to onMouseLeave, allowing hovering to work as expected, but without persistent effects.